### PR TITLE
Fix issue with not including attributes' namespaces such as 'xmlns'.

### DIFF
--- a/dom.go
+++ b/dom.go
@@ -4,6 +4,7 @@ package xmldom
 import (
 	"bytes"
 	"encoding/xml"
+	"fmt"
 	"io"
 	"os"
 	"strings"
@@ -48,8 +49,12 @@ func Parse(r io.Reader) (*Document, error) {
 			el.Parent = e
 			el.Name = token.Name.Local
 			for _, attr := range token.Attr {
+				name := attr.Name.Local
+				if attr.Name.Space != "" {
+					name = fmt.Sprintf("%s:%s", attr.Name.Space, attr.Name.Local)
+				}
 				el.Attributes = append(el.Attributes, &Attribute{
-					Name:  attr.Name.Local,
+					Name:  name,
 					Value: attr.Value,
 				})
 			}

--- a/example_test.go
+++ b/example_test.go
@@ -2,6 +2,7 @@ package xmldom_test
 
 import (
 	"fmt"
+	"testing"
 
 	"github.com/subchen/go-xmldom"
 )
@@ -16,6 +17,7 @@ const (
 		</properties>
 		<testcase classname="go-xmldom" id="ExampleParseXML" time="0.004"></testcase>
 		<testcase classname="go-xmldom" id="ExampleParse" time="0.005"></testcase>
+    <testcase xmlns:test="mock" id="AttrNamespace"></testcase>
 	</testsuite>
 </testsuites>`
 )
@@ -148,4 +150,13 @@ func ExampleNewDocument() {
 	//     <testcase name="case 2">FAIL</testcase>
 	//   </testsuite>
 	// </testsuites>
+}
+
+func TestAttrNamespace(t *testing.T) {
+	root := xmldom.Must(xmldom.ParseXML(ExampleXml)).Root
+	node := root.FindByID("AttrNamespace")
+
+	if node.Attributes[0].Name != "xmlns:test" {
+		t.Fatalf("Expected attribute name to be xmlns:test, got=%s", node.Attributes[0].Name)
+	}
 }


### PR DESCRIPTION
Motivation for that is that my app is relying on existence of xmlns:href attribute in svg's 'use' tags, so absence of xlmns in attributes name is breaking app's logic. I don't know much about namespaces in xml in general, so I only tested xmlns case.